### PR TITLE
Fix server start timer

### DIFF
--- a/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -85,7 +85,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
     }
 
     private boolean init() throws UnknownHostException { // CraftBukkit - added throws UnknownHostException
-        long startTimer = System.nanoTime(); // Tsunami
+        long startTimer = System.nanoTime(); // Tsunami - moved from below
 
         this.consoleCommandHandler = new ConsoleCommandHandler(this);
         ThreadCommandReader threadcommandreader = new ThreadCommandReader(this);
@@ -181,10 +181,11 @@ public class MinecraftServer implements Runnable, ICommandListener {
             this.propertyManager.savePropertiesFile();
         }
 
-        // CraftBukkit start
+        // Tsunami start - moved from above
         long elapsed = System.nanoTime() - startTimer;
-        String time = String.format("%.3fs", elapsed / 1000000000.0D); // Tsunami
+        String time = String.format("%.3fs", elapsed / 1000000000.0D);
         log.info("Done (" + time + ")! For help, type \"help\" or \"?\"");
+        // Tsunami end
 
         return true;
     }


### PR DESCRIPTION
In Poseidon, the server starting timer was shown as 10 times less than the measured value due to an extra digit in the time division. This also moves the timer start further back into the server initialization to improve the accuracy.
<img width="611" height="29" alt="image" src="https://github.com/user-attachments/assets/cdd6cc24-422e-455e-9994-9861efe747e1" />
(this is supposed to be 9.54s)

<img width="613" height="30" alt="image" src="https://github.com/user-attachments/assets/0e881cac-1161-4d1f-9100-671f3449c51e" />
