### PR TITLE
Fix double newlines being printed on newer java versions to console output and server log

### DIFF
--- a/src/main/java/net/minecraft/server/ConsoleLogFormatter.java
+++ b/src/main/java/net/minecraft/server/ConsoleLogFormatter.java
@@ -42,7 +42,13 @@ final class ConsoleLogFormatter extends Formatter {
         String message = ANSI_PATTERN.matcher(formattedMessage).replaceAll("");
         stringbuilder.append(message);
         // Tsunami end
-        stringbuilder.append('\n');
+
+        // Tsunami start - fix double newlines on newer Java versions
+        if (stringbuilder.charAt(stringbuilder.length() - 1) != '\n') {
+            stringbuilder.append('\n');
+        }
+        // Tsunami end
+
         Throwable throwable = logrecord.getThrown();
 
         if (throwable != null) {

--- a/src/main/java/org/bukkit/craftbukkit/util/ShortConsoleLogFormatter.java
+++ b/src/main/java/org/bukkit/craftbukkit/util/ShortConsoleLogFormatter.java
@@ -52,7 +52,7 @@ public class ShortConsoleLogFormatter extends Formatter {
         builder.append(record.getLevel().getLocalizedName().toUpperCase());
         builder.append("] ");
         builder.append(formattedMessage);
-        builder.append('\n');
+        // Tsunami - removed builder.append('\n');
 
         if (ex != null) {
             StringWriter writer = new StringWriter();


### PR DESCRIPTION
Tested and working on both java 8 and 21